### PR TITLE
Fix async/await syntax error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ export default Ember.Route.extend({
     })
 
     try {
-      const packageJson = async repo.readFile('package.json')
+      const packageJson = await repo.readFile('package.json')
       return { packageJson, repo }
     } catch (err) {
       // ...


### PR DESCRIPTION
I think you meant `await` instead of `async` here.